### PR TITLE
Fix missing total function count in contract generation

### DIFF
--- a/src/services/apiServices.ts
+++ b/src/services/apiServices.ts
@@ -173,6 +173,8 @@ Output ONLY valid JSON with the exact format specified.`
   ): Promise<{ name: string; code: string }[]> {
     // Parse the JSON directly
     const architecture = this.parseArchitectureJSON(architectureJson);
+    // Track total number of functions to implement for progress updates
+    const totalFunctions = architecture.functions.length;
     const implementedFunctions: { name: string; code: string }[] = [];
       
     // Process each function individually and verify implementation


### PR DESCRIPTION
## Summary
- track total function count when implementing functions to avoid `totalFunctions is not defined` error

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any, requires repo-wide fixes)*

------
https://chatgpt.com/codex/tasks/task_e_689f2cec5798832d8e9200454d7c275a